### PR TITLE
Document Partner API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ and operations for searching parts, placing orders and retrieving order status.
 ## Current Capabilities
 
 - Obtain a JWT token via `/token`.
-- Search for parts with `/search`.
-- Create an order using `/order`.
-- Check order status at `/order/{reference}`.
+- Search for parts with `/search` and inspect a single listing with `/listing/{listing_id}`.
+- Request available carrier services with `/shippingQuote`.
+- Create an order using `/order` and request a cancellation with `/order/{reference}/request-cancel`.
+- Retrieve order history with `/orders` and detailed order status at `/order/{reference}`.
+- Review credits with `/credits`.
+- Retrieve invoice summaries with `/invoices` and full invoice details with `/invoice/{id}`.
 
 The Markdown files in this repo provide request and response examples for each
 endpoint.

--- a/authentication.md
+++ b/authentication.md
@@ -5,20 +5,22 @@ layout: default
 
 ## API Authentication
 
-The API requires authentication using a client ID and client secret to obtain an access token. The access token is then used to authenticate each request until the expiration time (3 hours at the time of writing). After expiration, a new access token needs to be obtained.
+The API requires authentication using a client ID and client secret to obtain an access token. The access token is then used to
+authenticate each request until the expiration time (3 hours at the time of writing). After expiration, request a new token.
 
 ## Get a Token
 
-To obtain an access token, you need to make a POST request to the `/token` endpoint with the client ID and client secret in the request body.
+Send a POST request to `/token` with the client ID and client secret in the request body.
 
 ### POST Request to Obtain Token
-
 ```plaintext
-POST /api/partner/v1/token
+POST /api/partner/v1/token HTTP/1.1
+Host: base.shopjimmy.com
+Content-Type: application/json
 ```
 
 ### Request Body
-```js
+```json
 {
   "client_id": "your_client_id",
   "client_secret": "your_client_secret"
@@ -26,19 +28,36 @@ POST /api/partner/v1/token
 ```
 
 ### 200 Response
-```js
+```json
 {
   "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...",
-  "expires": "2024-08-08T12:34:56Z"
+  "expires": "2024-08-08T12:34:56.000Z"
 }
 ```
 
 ### 400 Response
-```js
+Returned when the provided credentials fail validation.
+```json
 {
-  "error": "Invalid client credentials"
+  "error": "Client ID must be a 32-character string"
 }
 ```
+
+### 403 Response
+Returned when the credentials are well-formed but do not match a registered partner application.
+```json
+{
+  "error": "Authentication failed. Client Not found."
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "Unexpected error message"
+}
+```
+
 ----
 
 [^1]: [It can take up to 10 minutes for changes to your site to publish after you push the changes to GitHub](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll#creating-your-site).

--- a/credits.md
+++ b/credits.md
@@ -1,0 +1,40 @@
+---
+title: Credits
+layout: default
+---
+
+## API Authentication
+
+To retrieve credits/refunds using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Returns credit memos created for orders placed by your partner account. Use the optional `days` query parameter to control the
+look-back window (defaults to 30 days).
+
+### GET Request to retrieve credits
+```plaintext
+GET /api/partner/v1/credits?days=60 HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### 200 Response
+```json
+[
+  {
+    "reference": "PAPI3ZAABG36JWR",
+    "amount": 25.0,
+    "reason": "Missing accessories",
+    "created_at": "2024-08-10T10:12:00.000Z"
+  }
+]
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/index.md
+++ b/index.md
@@ -16,8 +16,23 @@ Each order request must include the corresponding shipping service name and carr
 
 ---
 ### Billing
-All fulfilled orders will be invoiced electronically at a later time. 
+All fulfilled orders will be invoiced electronically at a later time.
 The billing address for each order will reference the API account information associated with your account.
+
+---
+
+### Available Endpoints
+- [Authentication](authentication.html)
+- [Search Listings](search.html)
+- [Listing Details](listing.html)
+- [Shipping Quote](shipping-quote.html)
+- [Create Order](order.html)
+- [Request Order Cancellation](order-request-cancel.html)
+- [Order History](orders.html)
+- [Order Status](order-status.html)
+- [Credits](credits.html)
+- [Invoices](invoices.html)
+- [Invoice Details](invoice.html)
 
 **Interact with our API using Swagger.io**
 

--- a/invoice.md
+++ b/invoice.md
@@ -1,0 +1,71 @@
+---
+title: Invoice Details
+layout: default
+---
+
+## API Authentication
+
+To retrieve a specific invoice using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Provide the numeric invoice `id` from the [`/invoices` endpoint](invoices.html) to fetch the full invoice record.
+
+### GET Request to retrieve an invoice
+```plaintext
+GET /api/partner/v1/invoice/{invoice_id} HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### 200 Response
+```json
+{
+  "id": 123456,
+  "sale": {
+    "created_at": "2024-08-07T13:24:02.000Z",
+    "reference": "PAPI3ZAABG36JWR",
+    "po_number": "PO-12345",
+    "billing_firstname": "Robin",
+    "billing_lastname": "Receiver",
+    "billing_company": "Warehouse Inc",
+    "billing_address1": "123 Warehouse Way",
+    "billing_address2": "Suite 100",
+    "billing_city": "Burnsville",
+    "billing_postcode": "55337",
+    "billing_region": "MN",
+    "billing_country": "US",
+    "billing_phone": "8005550100"
+  },
+  "items": [
+    {
+      "listing_id": 438195,
+      "sku": "sj-62661-2",
+      "qty": 1,
+      "price": 99.98,
+      "tax": 0
+    }
+  ],
+  "total": 99.98,
+  "tax": 0,
+  "shipping": 0,
+  "discount": 0,
+  "created_at": "2024-08-08T21:28:00.000Z"
+}
+```
+
+### 404 Response
+Returned when the invoice cannot be found.
+```json
+{
+  "error": "Invoice not found"
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/invoices.md
+++ b/invoices.md
@@ -1,0 +1,66 @@
+---
+title: Invoices
+layout: default
+---
+
+## API Authentication
+
+To retrieve invoices using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Returns invoices issued for orders placed by your partner account. Use the optional `days` query parameter to control the
+look-back window (defaults to 30 days). The invoice summary includes the original order metadata and each invoiced line item.
+
+### GET Request to retrieve invoices
+```plaintext
+GET /api/partner/v1/invoices?days=30 HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### 200 Response
+```json
+[
+  {
+    "id": 123456,
+    "sale": {
+      "created_at": "2024-08-07T13:24:02.000Z",
+      "reference": "PAPI3ZAABG36JWR",
+      "po_number": "PO-12345",
+      "billing_firstname": "Robin",
+      "billing_lastname": "Receiver",
+      "billing_company": "Warehouse Inc",
+      "billing_address1": "123 Warehouse Way",
+      "billing_address2": "Suite 100",
+      "billing_city": "Burnsville",
+      "billing_postcode": "55337",
+      "billing_region": "MN",
+      "billing_country": "US",
+      "billing_phone": "8005550100"
+    },
+    "items": [
+      {
+        "listing_id": 438195,
+        "sku": "sj-62661-2",
+        "qty": 1,
+        "price": 99.98,
+        "tax": 0
+      }
+    ],
+    "total": 99.98,
+    "tax": 0,
+    "shipping": 0,
+    "discount": 0,
+    "created_at": "2024-08-08T21:28:00.000Z"
+  }
+]
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/listing.md
+++ b/listing.md
@@ -1,0 +1,79 @@
+---
+title: Listing Details
+layout: default
+---
+
+## API Authentication
+
+To retrieve a listing using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Provide the numeric `listing_id` returned by the [`/search` endpoint](search.html) to fetch pricing, images, and compatibility
+details for a single listing.
+
+### GET Request to retrieve a listing
+```plaintext
+GET /api/partner/v1/listing/{listing_id} HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### 200 Response
+```json
+{
+  "id": 336076,
+  "title": "Hisense RUNTK0488FVZZ T-Con Board",
+  "sku": "sj-RUNTK0488FVZZ",
+  "price": 19.99,
+  "important": "RUNTK0488FVZZ can be found on barcode sticker on board..",
+  "qty": 4,
+  "parts_included": [
+    {
+      "manufacturer": "Hisense",
+      "part_number": "RUNTK0488FVZZ",
+      "qty": 1,
+      "actual_stock": 4,
+      "image": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+      "substitutes": [
+        {
+          "manufacturer": "Hisense",
+          "part_number": "RUNTK0488FVZA",
+          "stock": 4
+        }
+      ]
+    }
+  ],
+  "substitutes": [
+    {
+      "manufacturer": "Hisense",
+      "part_number": "RUNTK0488FVZA",
+      "stock": 4
+    }
+  ],
+  "image": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+  "images": [
+    {
+      "url": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+      "default": true,
+      "label": "Front"
+    }
+  ]
+}
+```
+
+### 404 Response
+Returned when the listing cannot be found.
+```json
+{
+  "error": "Listing not found"
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/order-request-cancel.md
+++ b/order-request-cancel.md
@@ -1,0 +1,37 @@
+---
+title: Request Order Cancellation
+layout: default
+---
+
+## API Authentication
+
+To request an order cancellation using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Submit a cancellation request for an order that has not yet shipped. The request posts a message to our shipping team for
+manual review.
+
+### POST Request to request cancellation
+```plaintext
+POST /api/partner/v1/order/{order_reference}/request-cancel HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+No body payload is required.
+
+### 200 Response
+```json
+{
+  "message": "Your request has been received."
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/order-status.md
+++ b/order-status.md
@@ -5,12 +5,12 @@ layout: default
 
 ## API Authentication
 
-To get an order's status using the Partner API, include the Authorization header in your HTTP request. 
-The Authorization header should contain a Bearer token, which is necessary to authenticate your search requests.
+To get an order's status using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
 
 ## Usage
-This action will show you an order's various timestamps of events, and also any packages that have been shipped including the items within.
-You will only be able to see orders that you've placed with your partner account.
+This action returns timestamps for order lifecycle events, a snapshot of the order items, invoices, credits, returns, and every
+package that has shipped. You can only retrieve orders that were placed by your partner account.
 
 ### GET Request to retrieve order
 ```plaintext
@@ -21,9 +21,63 @@ Content-Type: application/json
 ```
 
 ### 200 Response
-```js
+```json
 {
   "reference": "PAPI3ZAABG36JWR",
+  "po_number": "PO-12345",
+  "total": 199.95,
+  "note": "Purchase Order: PO-12345",
+  "items": [
+    {
+      "listing_id": 438195,
+      "sku": "sj-62661-2",
+      "qty": 1,
+      "paid": 99.98,
+      "tax": 0
+    }
+  ],
+  "credits": [
+    {
+      "reason": "Damaged in transit",
+      "amount": 10.0,
+      "created_at": "2024-08-09T14:20:00.000Z"
+    }
+  ],
+  "invoices": [
+    {
+      "id": 555432,
+      "items": [
+        {
+          "listing_id": 438195,
+          "sku": "sj-62661-2",
+          "qty": 1,
+          "price": 99.98,
+          "tax": 0
+        }
+      ],
+      "total": 99.98,
+      "tax": 0,
+      "shipping": 0,
+      "discount": 0,
+      "created_at": "2024-08-07T13:24:02.000Z"
+    }
+  ],
+  "returns": [
+    {
+      "id": 321,
+      "created_at": "2024-08-10T10:12:00.000Z",
+      "credited_at": null,
+      "denied_at": null,
+      "items": [
+        {
+          "listing_id": 438195,
+          "sku": "sj-62661-2",
+          "amount": 99.98,
+          "qty": 1
+        }
+      ]
+    }
+  ],
   "created_at": "2024-08-07T13:24:02.000Z",
   "shipped_at": "2024-08-08T21:28:00.000Z",
   "canceled_at": null,
@@ -45,12 +99,15 @@ Content-Type: application/json
       "destination_country": "US",
       "destination_telephone": "877-881-6492",
       "destination_business": "ShopJimmy.com",
+      "destination_email": "annie@example.com",
       "items": [
         {
           "listing_id": 438195,
           "sku": "sj-62661-2",
           "qty": 1,
-          "serial": null
+          "serial": null,
+          "part_number": "62661-2",
+          "substituted": false
         }
       ]
     }
@@ -58,15 +115,16 @@ Content-Type: application/json
 }
 ```
 
-### 400 Response
-```js
+### 404 Response
+Returned when the order is not found for your account.
+```json
 {
-  "error": "Validation failed ... reason ..."
+  "error": "Order not found."
 }
 ```
 
 ### 500 Response
-```js
+```json
 {
   "error": "There was an internal server error. Please contact administrator."
 }

--- a/order.md
+++ b/order.md
@@ -5,14 +5,14 @@ layout: default
 
 ## API Authentication
 
-To perform place order operation using the Partner API, include the Authorization header in your HTTP request. 
-The Authorization header should contain a Bearer token, which is necessary to authenticate your search requests.
+To place an order using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
 
 ## Usage
-Most of the information we need has already been saved to your account at this point.
-All we need here is the destination information, ship method, and item information.
+Most billing information is taken from your partner account profile. The payload supplies destination details, the requested
+carrier/service, and the line items from your search results. Provide a valid shipping phone number and at least one line item.
 
-Optionally include a PO number and we will do our best to add it to the shipping label.
+Use the [`/shippingQuote` endpoint](shipping-quote.html) to see which methods are enabled for your account.
 
 ### POST Request to place order
 ```plaintext
@@ -23,40 +23,49 @@ Content-Type: application/json
 ```
 
 ### Body JSON definition
-```js
+```json
 {
-  "po_number": "string",
-  "ship_method": "string",
-  "delivery_instructions": "string",
-  "destination_email": "user@example.com",
-  "destination_name": "string",
-  "destination_address_1": "string",
-  "destination_address_2": "string",
-  "destination_city": "string",
+  "po_number": "Optional PO number shown on packing slips",
+  "ship_method": "FedEx FedEx Next Day Air",
+  "delivery_instructions": "Leave at receiving desk",
+  "destination_email": "receiving@example.com",
+  "destination_name": "Robin Receiver",
+  "destination_address_1": "123 Warehouse Way",
+  "destination_address_2": "Suite 100",
+  "destination_city": "Burnsville",
   "destination_state": "MN",
-  "destination_postcode": "string",
+  "destination_postcode": "55337",
   "destination_country": "US",
-  "destination_telephone": "string",
-  "destination_business": "string",
+  "destination_telephone": "8005550100",
+  "destination_business": "Warehouse Inc",
   "items": [
     {
-      "listing_id": 0,
-      "qty": 0
+      "listing_id": 336076,
+      "qty": 2
     }
   ]
 }
 ```
 
 ### 200 Response
-```js
+```json
 {
   "reference": "PAPI3ZAABG36JWR"
 }
 ```
 
-### 500 Response
-```js
+### 400 Response
+Returned when the payload does not satisfy validation.
+```json
 {
-  "error": "There was an internal server error. Please contact administrator."
+  "error": "Validation failed {\"context\":{\"label\":\"ship_method\",\"value\":null}}"
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator.",
+  "message": "Detailed failure reason"
 }
 ```

--- a/orders.md
+++ b/orders.md
@@ -1,0 +1,53 @@
+---
+title: Order History
+layout: default
+---
+
+## API Authentication
+
+To retrieve order history using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Returns orders created for your partner account within the requested look-back window. Use the optional `days` query parameter
+to control the look-back window (defaults to 30 days). Each order includes key metadata plus line items and timestamps.
+
+### GET Request to retrieve orders
+```plaintext
+GET /api/partner/v1/orders?days=7 HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### 200 Response
+```json
+[
+  {
+    "reference": "PAPI3ZAABG36JWR",
+    "po_number": "PO-12345",
+    "customer_email": "receiving@example.com",
+    "customer_name": "Robin Receiver",
+    "total": 199.95,
+    "note": "Purchase Order: PO-12345",
+    "items": [
+      {
+        "listing_id": 438195,
+        "sku": "sj-62661-2",
+        "paid": 99.98,
+        "qty": 1
+      }
+    ],
+    "created_at": "2024-08-07T13:24:02.000Z",
+    "shipped_at": "2024-08-08T21:28:00.000Z",
+    "canceled_at": null
+  }
+]
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```

--- a/search.md
+++ b/search.md
@@ -5,20 +5,16 @@ layout: default
 
 ## API Authentication
 
-To perform search operations using the Partner API, include the Authorization header in your HTTP request. 
-The Authorization header should contain a Bearer token, which is necessary to authenticate your search requests.
+To perform search operations using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
 
 ## Usage
-Search queries go into the "q" query parameter of the url. Results are limited to 100. 
-There is no pagination. You must refine your search query to filter further.
-The "id" is what you will use to place an order for that listing in the next step.
+Search queries are supplied in the `q` query parameter. Results are limited to the first 100 matches for the provided term, so
+refine your query to narrow the response set. The `id` that is returned for each listing is used when creating an order.
 
-**These 3 characters are stripped from query and search index: `/ . -`**
+The characters `/`, `.`, and `-` are stripped from both the query and the search index and all matches are case insensitive.
 
-So you don't need to perform search in several ways. All searches are partials surrounded by % (wildcards) and are case insensitive.
-
-### Kits
-Some of our listings contain multiple parts (kits). So please be aware of the contents of the listing.
+Each result contains summary pricing, availability, and compatibility information in addition to part and image metadata.
 
 ### GET Request to search parts
 ```plaintext
@@ -29,92 +25,69 @@ Content-Type: application/json
 ```
 
 ### 200 Response
-```js
+```json
 [
   {
     "id": 336076,
     "title": "Hisense RUNTK0488FVZZ T-Con Board",
     "sku": "sj-RUNTK0488FVZZ",
     "price": 19.99,
-    "important": "RUNTK0488FVZZ can be found on barcode sticker on board..\\r\\n\\r\\nIMPORTANT: Horizontal lines on the screen are virtually NEVER caused by a bad T-con board. Horizontal lines indicate a defective LCD panel (screen).",
+    "important": "RUNTK0488FVZZ can be found on barcode sticker on board..\r\n\r\nIMPORTANT: Horizontal lines on the screen are virtually NEVER caused by a bad T-con board. Horizontal lines indicate a defective LCD panel (screen).",
     "qty": 1,
     "parts_included": [
       {
         "manufacturer": "Hisense",
         "part_number": "RUNTK0488FVZZ",
         "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg"
+        "actual_stock": 1,
+        "image": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+        "substitutes": [
+          {
+            "manufacturer": "Hisense",
+            "part_number": "RUNTK0488FVZA",
+            "stock": 4
+          }
+        ]
       }
     ],
-    "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
-    "score": 0
-  },
-  {
-    "id": 342548,
-    "title": "Onn RUNTK0506FVZA 6661TPZA T-Con Board",
-    "sku": "sj-RUNTK0506FVZA",
-    "price": 28.79,
-    "important": "",
-    "qty": 1,
-    "parts_included": [
+    "image": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+    "images": [
       {
-        "manufacturer": "ONN",
-        "part_number": "RUNTK0506FVZA",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-20-34-ShopJimmy-RUNTK0506FVZA-TOP.jpg"
+        "url": "https://cdn.example.com/2021-10-25-20-16-52-ShopJimmy-RUNTK0488FVZZ-TOP.jpg",
+        "default": true,
+        "label": "Front"
       }
     ],
-    "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-20-34-ShopJimmy-RUNTK0506FVZA-TOP.jpg",
-    "score": 0
-  },
-  {
-    "id": 342550,
-    "title": "ONN 100071708 TV Repair Parts Kit -Version 1",
-    "sku": "sj-KIT-100071708-K1",
-    "price": 40.81,
-    "important": "PLEASE NOTE: There are several versions of this TV model.  Please match the boards shown to the originals in your TV before ordering.",
-    "qty": 1,
-    "parts_included": [
+    "compatibility": [
       {
-        "manufacturer": "Element",
-        "part_number": "1246663",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-06-30-23-38-32-ShopJimmy-1246663-TOP.jpg"
-      },
-      {
-        "manufacturer": "Onn",
-        "part_number": "M22013-MT",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-07-49-ShopJimmy-M22013-MT-TOP.jpg"
-      },
-      {
-        "manufacturer": "Onn",
-        "part_number": "514C6508M04",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-01-14-ShopJimmy-514C6508M04-TOP.jpg"
-      },
-      {
-        "manufacturer": "ONN",
-        "part_number": "RUNTK0506FVZA",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-20-34-ShopJimmy-RUNTK0506FVZA-TOP.jpg"
-      },
-      {
-        "manufacturer": "Onn",
-        "part_number": "514Q50A0M15",
-        "qty": 1,
-        "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-10-59-ShopJimmy-514Q50A0M15-TOP.jpg"
+        "brand": "Hisense",
+        "model": "58H6550E",
+        "title": "Hisense 58H6550E",
+        "versions": "Version 1, Version 2"
       }
     ],
-    "image": "https://801dd59dc9cd6819c753-9e5e71dc742d0580ead74c66470ed43a.ssl.cf2.rackcdn.com/2022-12-23-01-22-42-ShopJimmy-KIT-100071708-K1-TOP.jpg",
-    "score": 0
+    "substitutes": [
+      {
+        "manufacturer": "Hisense",
+        "part_number": "RUNTK0488FVZA",
+        "stock": 4
+      }
+    ],
+    "score": 985
   }
 ]
 ```
 
 ### 400 Response
-```js
+```json
 {
   "error": "Missing search term."
+}
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
 }
 ```

--- a/shipping-quote.md
+++ b/shipping-quote.md
@@ -1,0 +1,58 @@
+---
+title: Shipping Quote
+layout: default
+---
+
+## API Authentication
+
+To request shipping methods using the Partner API, include the `Authorization` header in your HTTP request.
+The `Authorization` header must contain a Bearer token that you obtained from the [`/token` endpoint](authentication.html).
+
+## Usage
+Returns the carrier services that are enabled for your partner account based on the shipping accounts on file. The payload
+should include the destination address so the request can be validated.
+
+### POST Request to retrieve shipping methods
+```plaintext
+POST /api/partner/v1/shippingQuote HTTP/1.1
+Host: base.shopjimmy.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
+Content-Type: application/json
+```
+
+### Body JSON definition
+```json
+{
+  "destination_address_1": "123 Warehouse Way",
+  "destination_address_2": "Suite 100",
+  "destination_city": "Burnsville",
+  "destination_state": "MN",
+  "destination_postcode": "55337",
+  "destination_country": "US"
+}
+```
+
+### 200 Response
+```json
+[
+  {
+    "id": "FedEx Ground",
+    "label": "FedEx Ground",
+    "description": "5-7 business day arrival",
+    "amount": 0
+  },
+  {
+    "id": "UPS UPS Ground",
+    "label": "UPS Ground",
+    "description": "5-7 business day arrival",
+    "amount": 0
+  }
+]
+```
+
+### 500 Response
+```json
+{
+  "error": "There was an internal server error. Please contact administrator."
+}
+```


### PR DESCRIPTION
## Summary
- refresh authentication, search, order, and order status pages to match current API responses and errors
- add documentation for listing details, credits, invoices, order history, cancellation requests, and shipping quote endpoints
- surface endpoint quick links on the landing page and expand README capabilities overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de89e7d8dc832db5c73aa6c81eeb5f