### PR TITLE
Add Node.js request examples to API reference pages

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -27,6 +27,32 @@ Content-Type: application/json
 }
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function requestToken() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      client_id: 'your_client_id',
+      client_secret: 'your_client_secret'
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+requestToken().catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/credits.md
+++ b/credits.md
@@ -20,6 +20,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchCredits() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/credits?days=60', {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Credits request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchCredits().catch(console.error);
+```
+
 ### 200 Response
 ```json
 [

--- a/invoice.md
+++ b/invoice.md
@@ -19,6 +19,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchInvoice(invoiceId) {
+  const response = await fetch(`https://base.shopjimmy.com/api/partner/v1/invoice/${invoiceId}`, {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Invoice request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchInvoice(123456).catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/invoices.md
+++ b/invoices.md
@@ -20,6 +20,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchInvoices() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/invoices?days=30', {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Invoices request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchInvoices().catch(console.error);
+```
+
 ### 200 Response
 ```json
 [

--- a/listing.md
+++ b/listing.md
@@ -20,6 +20,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchListing(listingId) {
+  const response = await fetch(`https://base.shopjimmy.com/api/partner/v1/listing/${listingId}`, {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Listing request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchListing(336076).catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/order-request-cancel.md
+++ b/order-request-cancel.md
@@ -22,6 +22,29 @@ Content-Type: application/json
 
 No body payload is required.
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function requestOrderCancellation(orderReference) {
+  const response = await fetch(`https://base.shopjimmy.com/api/partner/v1/order/${orderReference}/request-cancel`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Cancellation request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+requestOrderCancellation('PAPI3ZAABG36JWR').catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/order-status.md
+++ b/order-status.md
@@ -20,6 +20,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchOrderStatus(orderReference) {
+  const response = await fetch(`https://base.shopjimmy.com/api/partner/v1/order/${orderReference}`, {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Order status request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchOrderStatus('PAPI3ZAABG36JWR').catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/order.md
+++ b/order.md
@@ -47,6 +47,50 @@ Content-Type: application/json
 }
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function createOrder() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/order', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      po_number: 'Optional PO number shown on packing slips',
+      ship_method: 'FedEx FedEx Next Day Air',
+      delivery_instructions: 'Leave at receiving desk',
+      destination_email: 'receiving@example.com',
+      destination_name: 'Robin Receiver',
+      destination_address_1: '123 Warehouse Way',
+      destination_address_2: 'Suite 100',
+      destination_city: 'Burnsville',
+      destination_state: 'MN',
+      destination_postcode: '55337',
+      destination_country: 'US',
+      destination_telephone: '8005550100',
+      destination_business: 'Warehouse Inc',
+      items: [
+        {
+          listing_id: 336076,
+          qty: 2
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Order request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+createOrder().catch(console.error);
+```
+
 ### 200 Response
 ```json
 {

--- a/orders.md
+++ b/orders.md
@@ -20,6 +20,28 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchOrders() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/orders?days=7', {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Orders request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchOrders().catch(console.error);
+```
+
 ### 200 Response
 ```json
 [

--- a/search.md
+++ b/search.md
@@ -24,6 +24,31 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IlE...
 Content-Type: application/json
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function searchListings(query) {
+  const url = new URL('https://base.shopjimmy.com/api/partner/v1/search');
+  url.searchParams.set('q', query);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Search request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+searchListings('PaRtNum83r').catch(console.error);
+```
+
 ### 200 Response
 ```json
 [

--- a/shipping-quote.md
+++ b/shipping-quote.md
@@ -32,6 +32,37 @@ Content-Type: application/json
 }
 ```
 
+### Node.js Example Request
+```javascript
+// Node.js 18+ example using the built-in fetch API
+async function fetchShippingQuotes() {
+  const response = await fetch('https://base.shopjimmy.com/api/partner/v1/shippingQuote', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer YOUR_ACCESS_TOKEN',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      destination_address_1: '123 Warehouse Way',
+      destination_address_2: 'Suite 100',
+      destination_city: 'Burnsville',
+      destination_state: 'MN',
+      destination_postcode: '55337',
+      destination_country: 'US'
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Shipping quote request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(data);
+}
+
+fetchShippingQuotes().catch(console.error);
+```
+
 ### 200 Response
 ```json
 [


### PR DESCRIPTION
## Summary
- add Node.js examples showing how to call each documented endpoint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8d933064832dbfbfa8333ff13cd4