### PR TITLE
Expand swagger specification to cover documented endpoints

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Partner API",
     "version": "1.0.0",
-    "description": "API for managing client tokens, searching listings, and creating orders."
+    "description": "API for managing authentication, catalog discovery, ordering, and post-order workflows."
   },
   "servers": [
     {
@@ -19,9 +19,29 @@
       }
     },
     "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Description of what went wrong."
+          },
+          "message": {
+            "type": "string",
+            "description": "Additional details about the error.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
       "TokenRequest": {
         "type": "object",
-        "required": ["client_id", "client_secret"],
+        "required": [
+          "client_id",
+          "client_secret"
+        ],
         "properties": {
           "client_id": {
             "type": "string",
@@ -49,9 +69,270 @@
           }
         }
       },
+      "SearchResultImage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "SearchResultSubstitute": {
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "type": "string"
+          },
+          "part_number": {
+            "type": "string"
+          },
+          "stock": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchResultPart": {
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "type": "string"
+          },
+          "part_number": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "actual_stock": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "substitutes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultSubstitute"
+            }
+          }
+        }
+      },
+      "SearchResultCompatibility": {
+        "type": "object",
+        "properties": {
+          "brand": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "versions": {
+            "type": "string"
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "important": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "parts_included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultPart"
+            }
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultImage"
+            }
+          },
+          "compatibility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultCompatibility"
+            }
+          },
+          "substitutes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultSubstitute"
+            }
+          },
+          "score": {
+            "type": "integer"
+          }
+        }
+      },
+      "ListingImage": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "ListingPart": {
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "type": "string"
+          },
+          "part_number": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "actual_stock": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "substitutes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultSubstitute"
+            }
+          }
+        }
+      },
+      "ListingResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "important": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "parts_included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListingPart"
+            }
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListingImage"
+            }
+          }
+        }
+      },
+      "ShippingQuoteRequest": {
+        "type": "object",
+        "required": [
+          "destination_address_1",
+          "destination_city",
+          "destination_state",
+          "destination_postcode",
+          "destination_country"
+        ],
+        "properties": {
+          "destination_address_1": {
+            "type": "string"
+          },
+          "destination_address_2": {
+            "type": "string"
+          },
+          "destination_city": {
+            "type": "string"
+          },
+          "destination_state": {
+            "type": "string"
+          },
+          "destination_postcode": {
+            "type": "string"
+          },
+          "destination_country": {
+            "type": "string"
+          }
+        }
+      },
+      "ShippingQuoteOption": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "format": "float"
+          }
+        }
+      },
       "OrderItem": {
         "type": "object",
-        "required": ["listing_id", "qty"],
+        "required": [
+          "listing_id",
+          "qty"
+        ],
         "properties": {
           "listing_id": {
             "type": "integer",
@@ -65,7 +346,12 @@
       },
       "OrderRequest": {
         "type": "object",
-        "required": ["ship_method", "destination_email", "destination_telephone", "items"],
+        "required": [
+          "ship_method",
+          "destination_email",
+          "destination_telephone",
+          "items"
+        ],
         "properties": {
           "po_number": {
             "type": "string",
@@ -148,124 +434,470 @@
           }
         }
       },
-      "OrderStatusResponse": {
+      "OrderSummaryItem": {
+        "type": "object",
+        "properties": {
+          "listing_id": {
+            "type": "integer"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "paid": {
+            "type": "number",
+            "format": "float"
+          },
+          "qty": {
+            "type": "integer"
+          }
+        }
+      },
+      "OrderSummary": {
         "type": "object",
         "properties": {
           "reference": {
+            "type": "string"
+          },
+          "po_number": {
+            "type": "string"
+          },
+          "customer_email": {
             "type": "string",
-            "description": "Reference number of the order."
+            "format": "email"
+          },
+          "customer_name": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          },
+          "note": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderSummaryItem"
+            }
           },
           "created_at": {
             "type": "string",
-            "format": "date-time",
-            "description": "Creation date of the order."
+            "format": "date-time"
           },
           "shipped_at": {
             "type": "string",
             "format": "date-time",
-            "description": "Shipment date of the order."
+            "nullable": true
           },
           "canceled_at": {
             "type": "string",
             "format": "date-time",
-            "description": "Cancellation date of the order."
+            "nullable": true
+          }
+        }
+      },
+      "OrderStatusItem": {
+        "type": "object",
+        "properties": {
+          "listing_id": {
+            "type": "integer"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "paid": {
+            "type": "number",
+            "format": "float"
+          },
+          "tax": {
+            "type": "number",
+            "format": "float"
+          }
+        }
+      },
+      "OrderStatusCredit": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "format": "float"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "InvoiceItem": {
+        "type": "object",
+        "properties": {
+          "listing_id": {
+            "type": "integer"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "tax": {
+            "type": "number",
+            "format": "float"
+          }
+        }
+      },
+      "InvoiceSale": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reference": {
+            "type": "string"
+          },
+          "po_number": {
+            "type": "string"
+          },
+          "billing_firstname": {
+            "type": "string"
+          },
+          "billing_lastname": {
+            "type": "string"
+          },
+          "billing_company": {
+            "type": "string"
+          },
+          "billing_address1": {
+            "type": "string"
+          },
+          "billing_address2": {
+            "type": "string"
+          },
+          "billing_city": {
+            "type": "string"
+          },
+          "billing_postcode": {
+            "type": "string"
+          },
+          "billing_region": {
+            "type": "string"
+          },
+          "billing_country": {
+            "type": "string"
+          },
+          "billing_phone": {
+            "type": "string"
+          }
+        }
+      },
+      "InvoiceSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sale": {
+            "$ref": "#/components/schemas/InvoiceSale"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceItem"
+            }
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          },
+          "tax": {
+            "type": "number",
+            "format": "float"
+          },
+          "shipping": {
+            "type": "number",
+            "format": "float"
+          },
+          "discount": {
+            "type": "number",
+            "format": "float"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OrderStatusInvoice": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceItem"
+            }
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          },
+          "tax": {
+            "type": "number",
+            "format": "float"
+          },
+          "shipping": {
+            "type": "number",
+            "format": "float"
+          },
+          "discount": {
+            "type": "number",
+            "format": "float"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OrderStatusReturnItem": {
+        "type": "object",
+        "properties": {
+          "listing_id": {
+            "type": "integer"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "format": "float"
+          },
+          "qty": {
+            "type": "integer"
+          }
+        }
+      },
+      "OrderStatusReturn": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "credited_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "denied_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusReturnItem"
+            }
+          }
+        }
+      },
+      "OrderStatusPackageItem": {
+        "type": "object",
+        "properties": {
+          "listing_id": {
+            "type": "integer"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "qty": {
+            "type": "integer"
+          },
+          "serial": {
+            "type": "string",
+            "nullable": true
+          },
+          "part_number": {
+            "type": "string",
+            "nullable": true
+          },
+          "substituted": {
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      },
+      "OrderStatusPackage": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dimensions": {
+            "type": "string"
+          },
+          "weight_lbs": {
+            "type": "number",
+            "format": "float"
+          },
+          "carrier": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "tracking_number": {
+            "type": "string"
+          },
+          "cost_usd": {
+            "type": "number",
+            "format": "float"
+          },
+          "destination_name": {
+            "type": "string"
+          },
+          "destination_address_1": {
+            "type": "string"
+          },
+          "destination_address_2": {
+            "type": "string"
+          },
+          "destination_city": {
+            "type": "string"
+          },
+          "destination_state": {
+            "type": "string"
+          },
+          "destination_postcode": {
+            "type": "string"
+          },
+          "destination_country": {
+            "type": "string"
+          },
+          "destination_telephone": {
+            "type": "string"
+          },
+          "destination_business": {
+            "type": "string"
+          },
+          "destination_email": {
+            "type": "string",
+            "format": "email",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusPackageItem"
+            }
+          }
+        }
+      },
+      "OrderStatusResponse": {
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string"
+          },
+          "po_number": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          },
+          "note": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusItem"
+            }
+          },
+          "credits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusCredit"
+            }
+          },
+          "invoices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusInvoice"
+            }
+          },
+          "returns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderStatusReturn"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shipped_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "canceled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
           "packages": {
             "type": "array",
             "items": {
-              "type": "object",
-              "properties": {
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time",
-                  "description": "Creation date of the package."
-                },
-                "dimensions": {
-                  "type": "string",
-                  "description": "Dimensions of the package."
-                },
-                "weight_lbs": {
-                  "type": "number",
-                  "description": "Weight of the package in pounds."
-                },
-                "carrier": {
-                  "type": "string",
-                  "description": "Carrier of the package."
-                },
-                "service": {
-                  "type": "string",
-                  "description": "Service type of the carrier."
-                },
-                "tracking_number": {
-                  "type": "string",
-                  "description": "Tracking number of the package."
-                },
-                "cost_usd": {
-                  "type": "number",
-                  "description": "Cost of shipping in USD."
-                },
-                "destination_name": {
-                  "type": "string",
-                  "description": "Name of the destination contact."
-                },
-                "destination_address_1": {
-                  "type": "string",
-                  "description": "First line of the destination address."
-                },
-                "destination_address_2": {
-                  "type": "string",
-                  "description": "Second line of the destination address."
-                },
-                "destination_city": {
-                  "type": "string",
-                  "description": "Destination city."
-                },
-                "destination_state": {
-                  "type": "string",
-                  "description": "Destination state."
-                },
-                "destination_postcode": {
-                  "type": "string",
-                  "description": "Destination postal code."
-                },
-                "destination_country": {
-                  "type": "string",
-                  "description": "Destination country code."
-                },
-                "destination_telephone": {
-                  "type": "string",
-                  "description": "Destination telephone number."
-                },
-                "destination_business": {
-                  "type": "string",
-                  "description": "Destination business name."
-                },
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "listing_id": {
-                        "type": "integer",
-                        "description": "Listing ID of the item."
-                      },
-                      "sku": {
-                        "type": "string",
-                        "description": "SKU of the item."
-                      },
-                      "qty": {
-                        "type": "integer",
-                        "description": "Quantity of the item in the package."
-                      },
-                      "serial": {
-                        "type": "string",
-                        "description": "Serial number of the item."
-                      }
-                    }
-                  }
-                }
-              }
+              "$ref": "#/components/schemas/OrderStatusPackage"
             }
+          }
+        }
+      },
+      "CreditSummary": {
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "format": "float"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RequestCancelResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
           }
         }
       }
@@ -306,12 +938,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -321,11 +948,146 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/search": {
+      "get": {
+        "summary": "Search listings",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search term to match against catalog listings."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing search term",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/listing/{listing_id}": {
+      "get": {
+        "summary": "Get listing details",
+        "parameters": [
+          {
+            "name": "listing_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Identifier of the listing returned from search."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listing details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListingResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Listing not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shippingQuote": {
+      "post": {
+        "summary": "Get available shipping services",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ShippingQuoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Shipping services returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ShippingQuoteOption"
                   }
                 }
               }
@@ -336,12 +1098,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -378,27 +1135,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Authorization failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -408,17 +1145,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
       }
     },
     "/order/{reference}": {
@@ -446,31 +1183,91 @@
               }
             }
           },
-          "403": {
-            "description": "Authorization failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
           "404": {
             "description": "Order not found",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/order/{reference}/request-cancel": {
+      "post": {
+        "summary": "Request order cancellation",
+        "parameters": [
+          {
+            "name": "reference",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Reference number of the order"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancellation request submitted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestCancelResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orders": {
+      "get": {
+        "summary": "List orders",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Look-back window (in days) for returned orders. Defaults to 30 days."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orders retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderSummary"
                   }
                 }
               }
@@ -481,12 +1278,139 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/credits": {
+      "get": {
+        "summary": "List credits",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Look-back window (in days) for returned credits. Defaults to 30 days."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credits retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CreditSummary"
                   }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoices": {
+      "get": {
+        "summary": "List invoices",
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Look-back window (in days) for returned invoices. Defaults to 30 days."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Invoices retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InvoiceSummary"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoice/{invoice_id}": {
+      "get": {
+        "summary": "Get invoice details",
+        "parameters": [
+          {
+            "name": "invoice_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Identifier of the invoice returned from the invoices endpoint."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Invoice details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceSummary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Invoice not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- expand component schemas to describe search results, listings, shipping quotes, order lifecycle, invoices, and credits
- document additional REST paths for catalog discovery, order management, fulfillment, credits, and invoices
- standardize reusable error responses and ensure the token endpoint remains unauthenticated

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de9157fc38832d88384051610b1d4c